### PR TITLE
feat:kafka framework created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.22</version>
 		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+		</dependency>
 	</dependencies>
   <build>
     <plugins>

--- a/src/main/java/cub/book/controller/BookController.java
+++ b/src/main/java/cub/book/controller/BookController.java
@@ -20,6 +20,8 @@ import cub.book.dto.BookQueryRq;
 import cub.book.dto.BookQueryRs;
 import cub.book.dto.BookUpdateRq;
 import cub.book.dto.base.CubResponse;
+import cub.book.entity.LogEntity;
+import cub.book.producer.BookProducer;
 import cub.book.service.BookService;
 
 @RequestScoped
@@ -27,18 +29,28 @@ import cub.book.service.BookService;
 public class BookController {
 
 	private BookService bookService;
+	
+	private BookProducer bookProducer;
 
 	@Inject
-	public BookController(BookService bookService) {
+	public BookController(BookService bookService,BookProducer bookProducer) {
 		this.bookService = bookService;
+		this.bookProducer = bookProducer;
 	}
 
 	@Operation(summary = "新增書籍")
 	@POST
 	@Path("/book/add")
 	public RestResponse<CubResponse<BookAddRq>> bookAdd(@Valid BookAddRq bookAddRq) {
-		CubResponse<BookAddRq> cubRs = bookService.insertBookData(bookAddRq);
 		LocalDateTime currentTime = LocalDateTime.now();
+		LogEntity logEntity = new LogEntity();
+		logEntity.setLogTime(currentTime);
+		logEntity.setLogType("INFO");
+		logEntity.setLogSource("bookAdd");
+		logEntity.setLogMessage("Sending Requests to API : bookAdd");
+		bookProducer.sendLogToKafka(logEntity);
+		
+		CubResponse<BookAddRq> cubRs = bookService.insertBookData(bookAddRq);
 		return ResponseBuilder.ok(cubRs, MediaType.APPLICATION_JSON).header("date", currentTime).build();
 	}
 

--- a/src/main/java/cub/book/entity/LogEntity.java
+++ b/src/main/java/cub/book/entity/LogEntity.java
@@ -1,0 +1,38 @@
+package cub.book.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.Id;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name="tb_log")
+public class LogEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name="log_id")	
+	private Integer logId;
+	
+	@Column(name="log_time")
+	private LocalDateTime logTime;
+	
+	@Column(name="log_type")	
+	private String logType;	
+	
+	@Column(name="log_source")	
+	private String logSource;
+
+	@Column(name="log_message")	
+	private String logMessage;	
+	
+}

--- a/src/main/java/cub/book/producer/BookProducer.java
+++ b/src/main/java/cub/book/producer/BookProducer.java
@@ -1,0 +1,21 @@
+package cub.book.producer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+
+import cub.book.entity.LogEntity;
+
+@ApplicationScoped
+public class BookProducer {
+		
+	@Inject @Channel("librarylog-out")
+    Emitter<LogEntity> emitterLog;
+	
+	public void sendLogToKafka(LogEntity logEntity) {
+		emitterLog.send(logEntity);	
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,13 @@ quarkus.redis.hosts=redis://localhost:6379
 quarkus.redis.password=02379
 
 server.port=8080
+
+# Outbound
+mp.messaging.outgoing.librarylog-out.connector=smallrye-kafka
+
+kafka.bootstrap.servers=PLAINTEXT://127.0.0.1:9092
+
+mp.messaging.outgoing.librarylog-out.topic=library_log
+mp.messaging.outgoing.librarylog-out.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+
+quarkus.http.port=8080


### PR DESCRIPTION
1. 新建 LogEntity 物件儲存 log 訊息
2. pom.xml 增加 quarkus-smallrye-reactive-messaging-kafka
3. application.properties 增加 kafka 連接參數 及 增加 quarkus.http.port
4. 新建 BookProducer 負責傳輸 LogEntity 物件至 kafka
5. 修改 BookController，注入 BookProducer 及 簡單增加使用 BookProducer method 來傳輸 LogEntity 物件 的範例在 bookAdd method