### PR TITLE
fix:RedisBookUpdate

### DIFF
--- a/src/main/java/cub/book/service/impl/BookServiceImpl.java
+++ b/src/main/java/cub/book/service/impl/BookServiceImpl.java
@@ -133,21 +133,22 @@ public class BookServiceImpl implements BookService {
 	@Transactional
 	public CubResponse<BookUpdateRq> bookUpdate(@Valid BookUpdateRq bookUpdateRq) {
 		CubResponse<BookUpdateRq> cubRs = new CubResponse<BookUpdateRq>();
-		String key = bookUpdateRq.getBookIsbn();
-		BookEntity bookEntity = new BookEntity();
-		bookEntity.setBookIsbn(bookUpdateRq.getBookIsbn());
-		bookEntity.setBookLanguage(bookUpdateRq.getBookLanguage());
-		bookEntity.setBookName(bookUpdateRq.getBookName());
-		bookEntity.setBookAuthor(bookUpdateRq.getBookAuthor());
-		bookEntity.setBookPublisher(bookUpdateRq.getBookPublisher());
-		bookEntity.setBookPubDate(bookUpdateRq.getBookPubDate());
-		bookEntity.setBookCreateDate(bookUpdateRq.getBookCreateDate());
-		bookEntity.setBookStatus(bookUpdateRq.getBookStatus());
-		redisService.set(key, bookEntity);
-		logUtils.message("INFO", "bookUpadte", "redis was update successful");
-
 		PanacheQuery<BookEntity> paBookEntity = bookRepository.find("bookIsbn", bookUpdateRq.getBookIsbn());
 		Optional<BookEntity> optBookEntity = paBookEntity.singleResultOptional();
+	
+//		String key = bookUpdateRq.getBookIsbn();
+//		BookEntity bookEntity = new BookEntity();
+//		bookEntity.setBookIsbn(bookUpdateRq.getBookIsbn());
+//		bookEntity.setBookLanguage(bookUpdateRq.getBookLanguage());
+//		bookEntity.setBookName(bookUpdateRq.getBookName());
+//		bookEntity.setBookAuthor(bookUpdateRq.getBookAuthor());
+//		bookEntity.setBookPublisher(bookUpdateRq.getBookPublisher());
+//		bookEntity.setBookPubDate(bookUpdateRq.getBookPubDate());
+//		bookEntity.setBookCreateDate(bookUpdateRq.getBookCreateDate());
+//		bookEntity.setBookStatus(bookUpdateRq.getBookStatus());
+//		redisService.set(key, bookEntity);
+//		logUtils.message("INFO", "bookUpadte", "redis was update successful");
+
 		try {
 			if (optBookEntity.isPresent()) {
 				BookEntity bookEntities = optBookEntity.get();
@@ -156,6 +157,8 @@ public class BookServiceImpl implements BookService {
 				logUtils.message("INFO", "bookUpadte", "mysql was update successful");
 				cubRs.setReturnCodeAndDesc(ReturnCodeEnum.SUCCESS);
 				logUtils.message("INFO", "bookUpadte", "response data: " + cubRs.toString());
+				redisService.deleteKeysAll();
+				logUtils.message("INFO", "bookUpadte", "redis was flushed successful");
 				return cubRs;
 			}
 			cubRs.setReturnCodeAndDesc(ReturnCodeEnum.E001, "，資料不存在");

--- a/src/main/java/cub/book/service/impl/BookServiceImpl.java
+++ b/src/main/java/cub/book/service/impl/BookServiceImpl.java
@@ -135,19 +135,6 @@ public class BookServiceImpl implements BookService {
 		CubResponse<BookUpdateRq> cubRs = new CubResponse<BookUpdateRq>();
 		PanacheQuery<BookEntity> paBookEntity = bookRepository.find("bookIsbn", bookUpdateRq.getBookIsbn());
 		Optional<BookEntity> optBookEntity = paBookEntity.singleResultOptional();
-	
-//		String key = bookUpdateRq.getBookIsbn();
-//		BookEntity bookEntity = new BookEntity();
-//		bookEntity.setBookIsbn(bookUpdateRq.getBookIsbn());
-//		bookEntity.setBookLanguage(bookUpdateRq.getBookLanguage());
-//		bookEntity.setBookName(bookUpdateRq.getBookName());
-//		bookEntity.setBookAuthor(bookUpdateRq.getBookAuthor());
-//		bookEntity.setBookPublisher(bookUpdateRq.getBookPublisher());
-//		bookEntity.setBookPubDate(bookUpdateRq.getBookPubDate());
-//		bookEntity.setBookCreateDate(bookUpdateRq.getBookCreateDate());
-//		bookEntity.setBookStatus(bookUpdateRq.getBookStatus());
-//		redisService.set(key, bookEntity);
-//		logUtils.message("INFO", "bookUpadte", "redis was update successful");
 
 		try {
 			if (optBookEntity.isPresent()) {


### PR DESCRIPTION
修改 BookServiceImp.java / bookUpdate 方法  
1.移除查找與修改Redis資料庫搜尋的程式。
2. 增加修改書籍成功後，清空Redis資料庫資料，並回傳卡夫卡訊息至SQL。
3. 測試如下：
![截圖 2023-02-02 22 28 14](https://user-images.githubusercontent.com/78682564/216351797-8438b689-1990-456b-b22a-3b9c007d081a.png)

接著確認Redis資料是否清空
<img width="441" alt="截圖 2023-02-02 22 29 40" src="https://user-images.githubusercontent.com/78682564/216352128-5eb09f1a-1807-4f0c-9eba-781d4ace88db.png">

查看sql 資料是否更新成功
<img width="831" alt="截圖 2023-02-02 22 31 12" src="https://user-images.githubusercontent.com/78682564/216352478-4a35ac41-bedb-4871-8604-3f6dc95378ad.png">

查看sql kafka 資料是否有新增事件 log
<img width="911" alt="截圖 2023-02-02 22 32 41" src="https://user-images.githubusercontent.com/78682564/216352803-10bbad49-15a0-4fe2-869b-1d86f2656d13.png">




