### PR TITLE
fix:RedisQueryCase1

### DIFF
--- a/src/main/java/cub/book/service/RedisService.java
+++ b/src/main/java/cub/book/service/RedisService.java
@@ -13,6 +13,7 @@ import cub.book.entity.BookEntity;
 //import io.quarkus.redis.datasource.ReactiveRedisDataSource;
 //import io.vertx.mutiny.redis.client.RedisAPI;
 import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.hash.HashCommands;
 import io.quarkus.redis.datasource.keys.KeyCommands;
 import io.quarkus.redis.datasource.set.SetCommands;
 import io.quarkus.redis.datasource.value.ValueCommands;
@@ -29,6 +30,7 @@ public class RedisService {
 	private final ValueCommands<String, BookEntity> commandsBookAddRq;
 	private final ValueCommands<String, BookEntity> commandsBookAllRq;
 	private final SetCommands<String, BookEntity> commandsBookQuery;
+	private HashCommands<String, String, BookEntity> commandsBookAll;
 	private KeyCommands<String> keys;
 
 	public RedisService(RedisDataSource ds) {
@@ -37,7 +39,16 @@ public class RedisService {
 		commandsBookAddRq = ds.value(BookEntity.class);
 		commandsBookAllRq = ds.value(BookEntity.class);
 		commandsBookQuery = ds.set(BookEntity.class);
+		commandsBookAll = ds.hash(BookEntity.class);
 		keys = ds.key();
+	}
+	
+	public void hsetAll(String key, String isbn, BookEntity bookEntity) {
+		commandsBookAll.hset(key, isbn, bookEntity);
+	}
+	
+	public List<BookEntity> hgetAll(String key) {
+		return commandsBookAll.hvals(key);
 	}
 
 	public BookEntity get(String key) {


### PR DESCRIPTION
RedisService：
1. 新增 redis hset、hvals 方法
2. 使用 hset 方法新增 hash 型態資料
3. 使用 hvals 方法讀取 hash 型態資料內的所有 Entity 物件
- This command overwrites the values of specified fields that exist in the hash. If key doesn't exist, a new key holding a hash is created.

BookRepository：
1. 修改 bookQuery case1 全部查詢與單筆查詢
2. 修改 bookQuery case1 redis 與 mysql 資料庫存取邏輯
3. 增加 bookQuery case1 判斷條件如果 Redis 資料存在就透過BookQueryCase1(key) 取得該 key 的 所有 value
4. 增加 bookQuery case1 判斷條件如果 Redis 資料不存在則透過 MySql DB 撈取資料，並建立 Redis 緩存
